### PR TITLE
Update imagemagick.Dockerfile

### DIFF
--- a/dockerfiles/imagemagick.Dockerfile
+++ b/dockerfiles/imagemagick.Dockerfile
@@ -4,4 +4,4 @@ RUN apk add --no-cache imagemagick
 
 WORKDIR /data
 
-ENTRYPOINT ["convert"]
+ENTRYPOINT ["magick"]


### PR DESCRIPTION
Changing entrypoint to fix:
```
WARNING: The convert command is deprecated in IMv7, use "magick" instead of "convert" or "magick convert"
```